### PR TITLE
Support built-in types and token annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ This project module was developed at Georgetown University.
 |---------------------|-------------------|-------------|
 |WebannoTSV.namespace			    |String           |webanno|
 |WebannoTSV.lowerTypes  |true,false       |false|
+|WebannoTSV.tokAnnos  |String       | |
 
 ### namespace
 
@@ -105,3 +106,8 @@ If `true`, relation annotation types, which WebAnno capitalizes automatically,
 will be lower-cased. For example, if you have an edge annotation `coref`, the
 WebAnno TSV export function will rename it to `Coref`. By setting this property
 to `true`, the name will be `coref` again. Default is `false`.
+
+### tokAnnos
+
+Supplies a semicolon-separated list of annotation names which should be attached directly to token, without creating span nodes above the covered area. Example value:
+`pos;lemma` (if annotations called pos and lemma are present, they are attached directly to their token, without creating a non-terminal node above the token).

--- a/src/main/java/org/corpus_tools/pepper_WebannoTSVModule/WebannoTSV2SaltMapper.java
+++ b/src/main/java/org/corpus_tools/pepper_WebannoTSVModule/WebannoTSV2SaltMapper.java
@@ -25,7 +25,6 @@ import org.corpus_tools.salt.common.STextualRelation;
 import org.corpus_tools.salt.common.SToken;
 import org.corpus_tools.salt.core.SAnnotation;
 import org.corpus_tools.salt.core.SLayer;
-import org.corpus_tools.salt.core.SNode;
 import org.eclipse.emf.common.util.URI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -296,10 +295,10 @@ public class WebannoTSV2SaltMapper extends PepperMapperImpl{
                                     
                                     String relField;
                                     if (iter.hasNext()){
-                                    relField = iter.next();
+                                        relField = iter.next();
                                     }
                                     else{
-                                        throw new PepperModuleDataException(this, "Anno field is: "  + annoField + " and currentAnnos is: " + currentAnno.getAnnoName() + " and has sisters: " + currentAnno.getNumSisters());
+                                        throw new PepperModuleDataException(this, "Insufficient columns found. Annotation field is: "  + annoField + " and currentAnnos is: " + currentAnno.getAnnoName() + " which has n sisters: " + currentAnno.getNumSisters());
                                     }
                                         
                                     sepRels = relField.split("\\|");
@@ -348,7 +347,6 @@ public class WebannoTSV2SaltMapper extends PepperMapperImpl{
 
                                                 WebannoTSVEdge rel = new WebannoTSVEdge(source,target,currentAnno.getNodeName(),currentAnno.getAnnoName(),edgeAnnoValue);
                                                 pointingRelationList.add(rel);
-                                                
                                             }
                                         }
                                     }
@@ -358,18 +356,13 @@ public class WebannoTSV2SaltMapper extends PepperMapperImpl{
                                         annoIndex++;
                                     }                                                    
                                 }
-
                             }
                         } else {
                             if (annoIndex < annotations.size()){ 
                                 annoIndex++; // moving annoIndex for empty anno column with "_"
                             }                                                    
                         }
-
                     }
-
-
-
                 }
 
                 // Finished reading an input tuple
@@ -437,7 +430,7 @@ public class WebannoTSV2SaltMapper extends PepperMapperImpl{
             for (WebannoTSVEdge edge : pointingRelationList) {
                 // Check that source and target are not identical
                 // Note that self-links are valid in WebAnno, but not in Salt
-                if (edge.getSourceID() != edge.getTargetID()) {
+                if (!edge.getSourceID().equals(edge.getTargetID())) {
                     SPointingRelation sRel = SaltFactory.createSPointingRelation();
                     if (spanIDMap.containsKey(edge.getSourceID())){
                         sRel.setSource(spanIDMap.get(edge.getSourceID()));

--- a/src/main/java/org/corpus_tools/pepper_WebannoTSVModule/WebannoTSV2SaltMapper.java
+++ b/src/main/java/org/corpus_tools/pepper_WebannoTSVModule/WebannoTSV2SaltMapper.java
@@ -365,29 +365,33 @@ public class WebannoTSV2SaltMapper extends PepperMapperImpl{
 
             // create SPointingRelations between SSpans if found
             for (WebannoTSVEdge edge : pointingRelationList) {
-                SPointingRelation sRel = SaltFactory.createSPointingRelation();
-                if (spanIDMap.containsKey(edge.getSourceID())){
-                    sRel.setSource(spanIDMap.get(edge.getSourceID()));
+                // Check that source and target are not identical
+                // Note that self-links are valid in WebAnno, but not in Salt
+                if (edge.getSourceID() != edge.getTargetID()) {
+                    SPointingRelation sRel = SaltFactory.createSPointingRelation();
+                    if (spanIDMap.containsKey(edge.getSourceID())){
+                        sRel.setSource(spanIDMap.get(edge.getSourceID()));
+                    }
+                    else{
+                        throw new PepperModuleDataException(this,"Input error: relation with missing source element: " + edge.getSourceID() + "\n" );
+                    }
+                    if (spanIDMap.containsKey(edge.getTargetID())){
+                        sRel.setTarget(spanIDMap.get(edge.getTargetID()));
+                    }
+                    else{
+                        throw new PepperModuleDataException(this,"Input error: relation with missing target element: " + edge.getTargetID() + "\n" );
+                    }
+                    sRel.setType(edge.getType());
+                    SAnnotation relAnno = SaltFactory.createSAnnotation();
+                    if (namespace != null){
+                        relAnno.setNamespace(namespace);
+                        sRel.addLayer(this.layer);
+                    }
+                    relAnno.setName(edge.getAnnoName());
+                    relAnno.setValue(edge.getAnnoValue());
+                    sRel.addAnnotation(relAnno);
+                    getDocument().getDocumentGraph().addRelation(sRel);
                 }
-                else{
-                    throw new PepperModuleDataException(this,"Input error: relation with missing source element: " + edge.getSourceID() + "\n" );
-                }
-                if (spanIDMap.containsKey(edge.getTargetID())){
-                    sRel.setTarget(spanIDMap.get(edge.getTargetID()));
-                }
-                else{
-                    throw new PepperModuleDataException(this,"Input error: relation with missing target element: " + edge.getTargetID() + "\n" );
-                }
-                sRel.setType(edge.getType());
-                SAnnotation relAnno = SaltFactory.createSAnnotation();
-                if (namespace != null){
-                    relAnno.setNamespace(namespace);
-                    sRel.addLayer(this.layer);
-                }
-                relAnno.setName(edge.getAnnoName());
-                relAnno.setValue(edge.getAnnoValue());
-                sRel.addAnnotation(relAnno);
-                getDocument().getDocumentGraph().addRelation(sRel);
             }
 
             return (DOCUMENT_STATUS.COMPLETED);

--- a/src/main/java/org/corpus_tools/pepper_WebannoTSVModule/WebannoTSVAnnotation.java
+++ b/src/main/java/org/corpus_tools/pepper_WebannoTSVModule/WebannoTSVAnnotation.java
@@ -30,12 +30,22 @@ public class WebannoTSVAnnotation {
 	private final WebannoTSVAnnotationType type;
 	private final String nodeName;
 	private final String annoName;
+	private final int numSisters; // records the number of coordinate annotations this annotations element carries
 
     
     WebannoTSVAnnotation(WebannoTSVAnnotationType type, String nodeName, String annoName) {
 		this.type = type;
                 this.nodeName = nodeName;
                 this.annoName = annoName;
+                this.numSisters = 1;
+        
+    }
+
+    WebannoTSVAnnotation(WebannoTSVAnnotationType type, String nodeName, String annoName, int sisters) {
+		this.type = type;
+                this.nodeName = nodeName;
+                this.annoName = annoName;
+                this.numSisters = sisters;
         
     }
     
@@ -50,6 +60,10 @@ public class WebannoTSVAnnotation {
 
     public String getAnnoName() {
         return annoName;
+    }
+
+    public int getNumSisters() {
+        return numSisters;
     }
 
     @Override

--- a/src/main/java/org/corpus_tools/pepper_WebannoTSVModule/WebannoTSVImporterProperties.java
+++ b/src/main/java/org/corpus_tools/pepper_WebannoTSVModule/WebannoTSVImporterProperties.java
@@ -30,10 +30,12 @@ public class WebannoTSVImporterProperties extends PepperModuleProperties  {
 
         public final static String NAMESPACE = PREFIX + "namespace";
 	public final static String LOWER_TYPES = PREFIX + "lowerTypes";
+	public final static String TOK_ANNOS = PREFIX + "tokAnnos";
 
 	public WebannoTSVImporterProperties() {
 		this.addProperty(new PepperModuleProperty<String>(NAMESPACE, String.class, "Specifies a namespace to assign to all imported annotations.", "webanno", false));
 		this.addProperty(new PepperModuleProperty<Boolean>(LOWER_TYPES, Boolean.class, "States whether to automatically lower-case all node and edge types, since these are capitalized automatically by Webanno.", false, false));
+		this.addProperty(new PepperModuleProperty<String>(LOWER_TYPES, String.class, "Supplies a semicolon-separated list of annotation names which should be attached directly to token, without creating span nodes above the covered area", "", false));
         }
 
     

--- a/src/main/java/org/corpus_tools/pepper_WebannoTSVModule/WebannoTSVMarkable.java
+++ b/src/main/java/org/corpus_tools/pepper_WebannoTSVModule/WebannoTSVMarkable.java
@@ -28,6 +28,7 @@ public class WebannoTSVMarkable {
     private ArrayList<SToken> tokens;
     private ArrayList<SAnnotation> annotations;
     private String nodeName;
+    private boolean isTokAnno;
 
     public String getNodeName() {
         return nodeName;
@@ -46,6 +47,14 @@ public class WebannoTSVMarkable {
 
     public ArrayList<SAnnotation> getAnnotations() {
         return annotations;
+    }
+
+    public boolean isIsTokAnno() {
+        return isTokAnno;
+    }
+
+    public void setIsTokAnno(boolean isTokAnno) {
+        this.isTokAnno = isTokAnno;
     }
     
 
@@ -69,6 +78,19 @@ public class WebannoTSVMarkable {
 
     void setNodeName(String name) {
         this.nodeName = name;
+    }
+
+    
+    @Override
+    public String toString(){
+        
+        StringBuilder coveredText = new StringBuilder();
+        for (SToken tok : this.tokens){
+            coveredText.append(tok.getId() + " ");
+        }
+        
+        return "WebannoTSVMarkable: " + this.nodeName +  " > " + coveredText.toString();
+              
     }
     
 }

--- a/src/test/java/org/corpus_tools/pepper_WebannoTSVModule/WebannoTSVImporterTest.java
+++ b/src/test/java/org/corpus_tools/pepper_WebannoTSVModule/WebannoTSVImporterTest.java
@@ -1,6 +1,8 @@
 package org.corpus_tools.pepper_WebannoTSVModule;
 
+import org.corpus_tools.pepper.modules.PepperModuleProperties;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import org.corpus_tools.pepper.testFramework.PepperImporterTest;
 import org.corpus_tools.salt.SaltFactory;
 import org.corpus_tools.salt.common.SDocument;
@@ -43,7 +45,7 @@ public class WebannoTSVImporterTest {
         
         
         @Test
-	public void testSentenceAnnotation()
+	public void testCustomAnnotation()
 	{
 	  getFixture().setResourceURI(URI.createFileURI("src/test/resources/GUM_webanno_test.tsv"));
 	  getFixture().mapSDocument();
@@ -60,9 +62,38 @@ public class WebannoTSVImporterTest {
           assertEquals(0, dg.getStructures().size());
           // checks that all pointing relations (subclass of relations) are
           // contained
-          assertEquals(117, dg.getPointingRelations().size());          
+          assertEquals(122, dg.getPointingRelations().size());          
           // checks that all relations are contained
-          assertEquals(2003, dg.getRelations().size());
+          assertEquals(2008, dg.getRelations().size());
         }
+        
+        @Test
+	public void testDepNER()
+	{
+	  getFixture().setResourceURI(URI.createFileURI("src/test/resources/PosDep.tsv"));
+          PepperModuleProperties props = new PepperModuleProperties();
+          props.setPropertyValue("WebannoTSV.tokAnnos", "PosValue");
+          props.setPropertyValue("WebannoTSV.lowerTypes", false);
+          getFixture().setProperties(props);
+	  getFixture().mapSDocument();
+	  
+	  SDocumentGraph dg = getFixture().getDocument().getDocumentGraph();
 
+          // check token count
+	  assertEquals(86, dg.getTokens().size());
+          // check that POS annotations were correctly attached to tokens
+          assertNotNull(dg.getTokens().get(0).getAnnotation("webanno","PosValue"));
+          // checks that all nodes are contained
+          assertEquals(92, dg.getNodes().size());
+          // checks that all spans (subclass of nodes) are contained
+          assertEquals(5, dg.getSpans().size());
+          // checks that all structures (subclass of nodes) are contained
+          assertEquals(0, dg.getStructures().size());
+          // checks that all pointing relations (subclass of relations) are
+          // contained
+          assertEquals(158, dg.getPointingRelations().size());          
+          assertEquals(true, (dg.getPointingRelations().size()>0));          
+          // checks that all relations are contained
+          assertEquals(254, dg.getRelations().size());
+        }
 }

--- a/src/test/resources/PosDep.tsv
+++ b/src/test/resources/PosDep.tsv
@@ -1,0 +1,106 @@
+#FORMAT=WebAnno TSV 3
+#T_SP=de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.POS|PosValue
+#T_SP=de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity|value
+#T_RL=de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.Dependency|DependencyType|flavor|BT_de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.POS
+
+
+#Text=Ms. Haag plays Elianti .
+1-1	0-3	Ms.	NNP	PER[1]	SUBJ	*	1-3	
+1-2	4-8	Haag	NNP	PER[1]	SBJ	*	1-3	
+1-3	9-14	plays	VBD	_	P|ROOT	*|*	1-5|1-3	
+1-4	15-22	Elianti	NNP	OTH	OBJ	*	1-3	
+1-5	23-24	.	.	_	_	_	_	
+
+#Text=Rolls-Royce Motor Cars Inc. said it expects its U.S. sales to remain steady at about 1,200 cars in 1990 .
+2-1	25-36	Rolls-Royce	NNP	ORG[3]	NAME	*	2-3	
+2-2	37-42	Motor	NNP	ORG[3]	NAME	*	2-3	
+2-3	43-47	Cars	NNPS	_	SBJ	*	2-5	
+2-4	48-52	Inc.	NNP	_	POSTHON	*	2-3	
+2-5	53-57	said	VBD	_	ROOT	*	2-5	
+2-6	58-60	it	PRP	_	SBJ	*	2-7	
+2-7	61-68	expects	VBZ	_	OBJ|OPRD	*|*	2-5|2-11	
+2-8	69-72	its	PRP$	_	NMOD	*	2-10	
+2-9	73-77	U.S.	NNP	LOC	NMOD	*	2-10	
+2-10	78-83	sales	NNS	_	OBJ	*	2-7	
+2-11	84-86	to	TO	_	_	_	_	
+2-12	87-93	remain	VB	_	IM	*	2-11	
+2-13	94-100	steady	JJ	_	PRD	*	2-12	
+2-14	101-103	at	IN	_	LOC	*	2-13	
+2-15	104-109	about	IN	_	DEP	*	2-16	
+2-16	110-115	1,200	CD	_	NMOD	*	2-17	
+2-17	116-120	cars	NNS	_	PMOD|TMP	*|*	2-14|2-18	
+2-18	121-123	in	IN	_	_	_	_	
+2-19	124-128	1990	CD	_	PMOD	*	2-18	
+2-20	129-130	.	.	_	P	*	2-5	
+
+#Text=The luxury auto maker last year sold 1,214 cars in the U.S.
+3-1	131-134	The	DT	_	NMOD	*	3-4	
+3-2	135-141	luxury	NN	_	NMOD	*	3-3	
+3-3	142-146	auto	NN	_	NMOD	*	3-4	
+3-4	147-152	maker	NN	_	SBJ	*	3-7	
+3-5	153-157	last	JJ	_	NMOD	*	3-6	
+3-6	158-162	year	NN	_	TMP	*	3-4	
+3-7	163-167	sold	VBD	_	ROOT	*	3-7	
+3-8	168-173	1,214	CD	_	NMOD	*	3-9	
+3-9	174-178	cars	NNS	_	OBJ	*	3-7	
+3-10	179-181	in	IN	_	LOC	*	3-9	
+3-11	182-185	the	DT	_	NMOD	*	3-12	
+3-12	186-190	U.S.	NNP	LOC	PMOD	*	3-10	
+
+#Text=BELL INDUSTRIES Inc. increased its quarterly to 10 cents from seven cents a share .
+4-1	191-195	BELL	NNP	ORG[6]|PER[7]	NAME	*	4-2	
+4-2	196-206	INDUSTRIES	NNP	ORG[6]	SBJ	*	4-4	
+4-3	207-211	Inc.	NNP	ORG[6]	POSTHON	*	4-2	
+4-4	212-221	increased	VBD	_	ROOT	*	4-4	
+4-5	222-225	its	PRP$	_	NMOD	*	4-6	
+4-6	226-235	quarterly	NN	_	OBJ	*	4-4	
+4-7	236-238	to	TO	_	DIR	*	4-4	
+4-8	239-241	10	CD	_	NMOD	*	4-9	
+4-9	242-247	cents	NNS	_	PMOD	*	4-7	
+4-10	248-252	from	IN	_	DIR	*	4-9	
+4-11	253-258	seven	CD	_	NMOD	*	4-12	
+4-12	259-264	cents	NNS	_	PMOD	*	4-10	
+4-13	265-266	a	DT	_	NMOD	*	4-14	
+4-14	267-272	share	NN	_	ADV	*	4-12	
+4-15	273-274	.	.	_	P	*	4-4	
+
+#Text=The new rate will be payable Feb. 15 .
+5-1	275-278	The	DT	_	NMOD	*	5-3	
+5-2	279-282	new	JJ	_	NMOD	*	5-3	
+5-3	283-287	rate	NN	_	SBJ	*	5-4	
+5-4	288-292	will	MD	_	ROOT	*	5-4	
+5-5	293-295	be	VB	_	VC	*	5-4	
+5-6	296-303	payable	JJ	_	PRD	*	5-5	
+5-7	304-308	Feb.	NNP	_	TMP	*	5-5	
+5-8	309-311	15	CD	_	NMOD	*	5-7	
+5-9	312-313	.	.	_	P	*	5-4	
+
+#Text=A record date has n't been set .
+6-1	314-315	A	DT	_	NMOD	*	6-3	
+6-2	316-322	record	NN	_	NMOD	*	6-3	
+6-3	323-327	date	NN	_	SBJ	*	6-4	
+6-4	328-331	has	VBZ	_	ROOT	*	6-4	
+6-5	332-335	n't	RB	_	ADV	*	6-4	
+6-6	336-340	been	VBN	_	VC	*	6-4	
+6-7	341-344	set	VBN	_	VC	*	6-6	
+6-8	345-346	.	.	_	P	*	6-4	
+
+#Text=Bell , based in Los Angeles , makes and distributes electronic , computer and building products .
+7-1	347-351	Bell	NNP	ORG	SBJ	*	7-8	
+7-2	352-353	,	,	_	P	*	7-1	
+7-3	354-359	based	VBN	_	APPO	*	7-1	
+7-4	360-362	in	IN	_	LOC	*	7-3	
+7-5	363-366	Los	NNP	LOC[9]	NAME	*	7-6	
+7-6	367-374	Angeles	NNP	LOC[9]	PMOD	*	7-4	
+7-7	375-376	,	,	_	P	*	7-1	
+7-8	377-382	makes	VBZ	_	ROOT	*	7-8	
+7-9	383-386	and	CC	_	COORD	*	7-8	
+7-10	387-398	distributes	VBZ	_	CONJ	*	7-9	
+7-11	399-409	electronic	JJ	_	NMOD	*	7-16	
+7-12	410-411	,	,	_	P	*	7-11	
+7-13	412-420	computer	NN	_	COORD	*	7-11	
+7-14	421-424	and	CC	_	COORD	*	7-13	
+7-15	425-433	building	NN	_	CONJ	*	7-14	
+7-16	434-442	products	NNS	_	OBJ	*	7-8	
+7-17	443-444	.	.	_	P	*	7-8	
+


### PR DESCRIPTION
- Built in types like dependencies and NER now importable
- Configuration for token annotations - selected annotations now attach directly to tokens without non-terminals
- Fixed bug involving self-links (forbidden in Salt, therefore now caught and ignored)
- Support for edges with multiple annotations
